### PR TITLE
Switch to simplified DB configuration

### DIFF
--- a/src/config/typeorm.config.ts
+++ b/src/config/typeorm.config.ts
@@ -6,11 +6,7 @@ export const getTypeOrmConfigAsync: TypeOrmModuleAsyncOptions = {
   inject: [ConfigService],
   useFactory: (config: ConfigService): TypeOrmModuleOptions => ({
     type: 'postgres',
-    host: config.get<string>('DB_HOST', ''),
-    port: config.get<number>('DB_PORT', 0),
-    username: config.get<string>('DB_USERNAME', ''),
-    password: config.get<string>('DB_PASSWORD', ''),
-    database: config.get<string>('DB_NAME', ''),
+    url: config.get<string>('DB_URL', ''),
     autoLoadEntities: true,
     synchronize: true,
   }),


### PR DESCRIPTION
The updated code simplifies the database setup in typeorm.config.ts. Instead of setting individual connection parameters like host, port, username, password, and database name, the application now fetches the entire configuration from a single 'DB_URL' environment variable. This change simplifies the configuration and makes it easier to switch between different databases/environments.